### PR TITLE
ft(168030615) A mentor can reject a mentorship session request

### DIFF
--- a/server/src/v1/controllers/sessionsController.js
+++ b/server/src/v1/controllers/sessionsController.js
@@ -18,4 +18,22 @@ const createSession = (req, res) => {
   });
 };
 
-export { createSession };
+const declineRequest = (req, res) => {
+  const { sessionId } = req.params;
+  const {
+    mentorId, menteeId, questions, menteeEmail, status,
+  } = Session.decline(sessionId);
+  res.status(200).json({
+    status: 200,
+    data: {
+      sessionId,
+      mentorId,
+      menteeId,
+      questions,
+      menteeEmail,
+      status,
+    },
+  });
+};
+
+export { createSession, declineRequest };

--- a/server/src/v1/middleware/verify.js
+++ b/server/src/v1/middleware/verify.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import User from '../models/User';
+import Session from '../models/Session';
 
 const verifyNewUser = (req, res, next) => {
   const user = User.findByEmail(req.body.email.trim());
@@ -77,14 +78,38 @@ const checkMentor = (req, res, next) => {
   const { mentorId } = req.body;
   const mentor = User.findOne(mentorId);
   if (!mentor || mentor.role !== 'mentor') {
-    return res.status(403).json({
-      status: 403,
+    return res.status(400).json({
+      status: 400,
       error: 'Not a mentor',
     });
   }
   next();
 };
 
+const verifyMentor = (req, res, next) => {
+  const mentorId = req.decoded.payload;
+  const mentor = User.findOne(mentorId);
+  if (!mentor || mentor.role !== 'mentor') {
+    return res.status(403).json({
+      status: 403,
+      error: 'Not a mentor, no permission',
+    });
+  }
+  next();
+};
+
+const verifySession = (req, res, next) => {
+  const result = Session.findOne(req.params.sessionId);
+  if (!result) {
+    return res.status(400).json({
+      status: 400,
+      error: `The session with id ${req.params.sessionId} does not exist in the app!`,
+    });
+  }
+  next();
+};
+
 export {
-  verifyNewUser, verifyExistingUser, verifyAuthUser, verifyAdmin, checkUser, checkMentor
+  verifyNewUser, verifyExistingUser, verifyAuthUser, verifyAdmin, checkUser, checkMentor,
+  verifyMentor, verifySession,
 };

--- a/server/src/v1/models/Session.js
+++ b/server/src/v1/models/Session.js
@@ -21,6 +21,18 @@ class Session {
     return newSession;
   }
 
+  decline(id) {
+    const session = this.sessions.find(sessionItem => sessionItem.id === id);
+    const index = this.sessions.indexOf(session);
+    this.sessions[index].status = 'Reject';
+
+    return this.sessions[index];
+  }
+
+  findOne(id) {
+    return this.sessions.find(session => session.id === id);
+  }
+
   remove() {
     this.sessions = [];
   }

--- a/server/src/v1/routes/sessionsRoutes.js
+++ b/server/src/v1/routes/sessionsRoutes.js
@@ -1,11 +1,14 @@
 import { Router } from 'express';
-import { verifyAuthUser, checkMentor } from '../middleware/verify';
-import { createSession } from '../controllers/sessionsController';
+import {
+  verifyAuthUser, checkMentor, verifyMentor, verifySession,
+} from '../middleware/verify';
+import { createSession, declineRequest } from '../controllers/sessionsController';
 
 const router = Router();
 
 router.use(verifyAuthUser);
 
 router.post('/', checkMentor, createSession);
+router.patch('/:sessionId/reject', verifyMentor, verifySession, declineRequest);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- adds endpoint *PATCH localhost:8001/api/v1/sessions/:sessionId/reject*
- adds unit tests to test the endpoint


#### Description of Task to be completed
- creates an endpoint that allows a mentor to reject a session request


#### How should this be manually tested?
- clone this repo
- create a .env file and add all environmental variables listed in the .env
- move to the branch *ft-mentor-decline-session-168030615*
- run the command *npm run dev:start* on the terminal to start the server
- on Postman test the endpoint  *PATCH localhost:8001/api/v1/sessions/:sessionId/reject*

#### Any background context you want to provide?
- N/A


#### What are the relevant pivotal tracker stories?
[#168030615](https://www.pivotaltracker.com/n/projects/2382168)

#### Screenshots (if appropriate)
- N/A